### PR TITLE
use package [utf8] instead of [utf8x]

### DIFF
--- a/doc/PyScanFCS_doc.tex
+++ b/doc/PyScanFCS_doc.tex
@@ -3,7 +3,7 @@
 %Wir arbeiten mit PDF-Latex.
 %Bei Texmaker unter Werkzeuge > PDFLaTeX (F6)
 
-\usepackage[utf8x]{inputenc}
+\usepackage[utf8]{inputenc}
 
 %Für deutsche Schriften:
 %\usepackage[ngerman]{babel}


### PR DESCRIPTION
Some time ago, we identified in [Debian bug #1016342] that the utf8x mode of the LaTeX package inputenc stopped operating properly.  This patch moves to plain utf8.

[Debian bug #1016342]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1016342